### PR TITLE
Rename Constants class

### DIFF
--- a/samples/UsageSample/Startup.cs
+++ b/samples/UsageSample/Startup.cs
@@ -48,7 +48,7 @@ $@"
   var currentResult = document.getElementById('get-current-result-js');
 
   getCurrent.addEventListener('click', function() {{
-    fetch('{Constants.TemporalOptions.DefaultTemporalRootPath + Constants.TemporalOptions.CurrentInfoEndpoint}',
+    fetch('{TemporalConstants.TemporalOptions.DefaultTemporalRootPath + TemporalConstants.TemporalOptions.CurrentInfoEndpoint}',
         {{ credentials: 'same-origin' }})
       .then(function(res) {{
         res.json().then(function(json) {{

--- a/src/Temporal/Temporal.csproj
+++ b/src/Temporal/Temporal.csproj
@@ -62,7 +62,7 @@
     <Compile Include="..\..\common\SolutionInfo.cs">
       <Link>Properties\SolutionInfo.cs</Link>
     </Compile>
-    <Compile Include="Constants.cs" />
+    <Compile Include="TemporalConstants.cs" />
     <Compile Include="CookieService.cs" />
     <Compile Include="CookieTimeProvider.cs" />
     <Compile Include="ITimeProvider.cs" />

--- a/src/Temporal/Temporal.nuspec
+++ b/src/Temporal/Temporal.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Temporal</id>
     <title>Temporal</title>
-    <version>1.0.0-alpha1</version>
+    <version>1.0.0-alpha2</version>
     <authors>Ritter Insurance Marketing</authors>
     <licenseUrl>https://raw.githubusercontent.com/ritterim/temporal/master/LICENSE</licenseUrl>
     <projectUrl>https://github.com/ritterim/temporal</projectUrl>

--- a/src/Temporal/TemporalConstants.cs
+++ b/src/Temporal/TemporalConstants.cs
@@ -1,6 +1,6 @@
 ﻿namespace Temporal
 {
-    public static class Constants
+    public static class TemporalConstants
     {
         public static class TemporalOptions
         {

--- a/src/Temporal/TemporalOptions.cs
+++ b/src/Temporal/TemporalOptions.cs
@@ -6,7 +6,7 @@ namespace Temporal
     {
         private readonly string _temporalRootPath;
 
-        public TemporalOptions(string temporalRootPath = Constants.TemporalOptions.DefaultTemporalRootPath)
+        public TemporalOptions(string temporalRootPath = TemporalConstants.TemporalOptions.DefaultTemporalRootPath)
         {
             _temporalRootPath = temporalRootPath;
 
@@ -14,9 +14,9 @@ namespace Temporal
                 _temporalRootPath += "/";
         }
 
-        public string CurrentInfoUri => _temporalRootPath + Constants.TemporalOptions.CurrentInfoEndpoint;
-        public string FreezeUri => _temporalRootPath + Constants.TemporalOptions.FreezeEndpoint;
-        public string UnfreezeUri => _temporalRootPath + Constants.TemporalOptions.UnfreezeEndpoint;
+        public string CurrentInfoUri => _temporalRootPath + TemporalConstants.TemporalOptions.CurrentInfoEndpoint;
+        public string FreezeUri => _temporalRootPath + TemporalConstants.TemporalOptions.FreezeEndpoint;
+        public string UnfreezeUri => _temporalRootPath + TemporalConstants.TemporalOptions.UnfreezeEndpoint;
 
         /// <summary>
         /// The current alignment of the on-screen time machine.

--- a/src/Temporal/TimeMachine.cs
+++ b/src/Temporal/TimeMachine.cs
@@ -27,8 +27,8 @@ namespace Temporal
 <div id=""temporal-time-machine-widget-js""
      class=""temporal-time-machine-widget temporal-time-machine-alignment-{_options.TimeMachineAlignment.ToString().ToLowerInvariant()}""
      data-temporal-time-machine-auto-refresh=""{_options.AutoRefresh.ToString().ToLowerInvariant()}""
-     data-temporal-time-machine-freeze-endpoint=""{Constants.TemporalOptions.DefaultTemporalRootPath + Constants.TemporalOptions.FreezeEndpoint}""
-     data-temporal-time-machine-unfreeze-endpoint=""{Constants.TemporalOptions.DefaultTemporalRootPath + Constants.TemporalOptions.UnfreezeEndpoint}"">
+     data-temporal-time-machine-freeze-endpoint=""{TemporalConstants.TemporalOptions.DefaultTemporalRootPath + TemporalConstants.TemporalOptions.FreezeEndpoint}""
+     data-temporal-time-machine-unfreeze-endpoint=""{TemporalConstants.TemporalOptions.DefaultTemporalRootPath + TemporalConstants.TemporalOptions.UnfreezeEndpoint}"">
   <div id=""temporal-time-machine-header-js""
        class=""temporal-time-machine-header"">
     <h2 class=""temporal-time-machine-title"">


### PR DESCRIPTION
- Rename the `Constants` class to `TemporalConstants` to avoid potential collisions with target projects.
- Version `1.0.0-alpha2`.