### PR TITLE
Default to SystemClockProvider

### DIFF
--- a/src/Temporal/Temporal.nuspec
+++ b/src/Temporal/Temporal.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Temporal</id>
     <title>Temporal</title>
-    <version>1.0.0-alpha2</version>
+    <version>1.0.0-alpha3</version>
     <authors>Ritter Insurance Marketing</authors>
     <licenseUrl>https://raw.githubusercontent.com/ritterim/temporal/master/LICENSE</licenseUrl>
     <projectUrl>https://github.com/ritterim/temporal</projectUrl>

--- a/src/Temporal/TemporalTime.cs
+++ b/src/Temporal/TemporalTime.cs
@@ -24,7 +24,9 @@ namespace Temporal
         {
             get
             {
-                return TimeProviders.FirstOrDefault(x => x.Now.HasValue);
+                var timeProvider = TimeProviders.FirstOrDefault(x => x.Now.HasValue);
+
+                return timeProvider ?? new SystemClockProvider();
             }
         }
 
@@ -43,28 +45,12 @@ namespace Temporal
 
         public static DateTime Now
         {
-            get
-            {
-                if (CurrentTimeProvider == null)
-                {
-                    throw new ApplicationException("No time provider is ready to return the time.");
-                }
-
-                return CurrentTimeProvider.Now.Value;
-            }
+            get { return CurrentTimeProvider.Now.Value; }
         }
 
         public static DateTime UtcNow
         {
-            get
-            {
-                if (CurrentTimeProvider == null)
-                {
-                    throw new ApplicationException("No time provider is ready to return the time.");
-                }
-
-                return CurrentTimeProvider.UtcNow.Value;
-            }
+            get { return CurrentTimeProvider.UtcNow.Value; }
         }
     }
 }

--- a/tests/Temporal.Tests/TemporalTimeTests.cs
+++ b/tests/Temporal.Tests/TemporalTimeTests.cs
@@ -48,11 +48,11 @@ namespace Temporal.Tests
         }
 
         [Fact]
-        public void CurrentTimeProvider_ReturnsNullWhenNoTimeProvidersHaveTheTime()
+        public void CurrentTimeProvider_UsesSystemClockProviderWhenNoTimeProvidersHaveTheTime()
         {
             TemporalTime.AddTimeProvider(new NoTimeTestTimeProvider());
 
-            Assert.Null(TemporalTime.CurrentTimeProvider);
+            Assert.IsType<SystemClockProvider>(TemporalTime.CurrentTimeProvider);
         }
 
         [Fact]
@@ -91,51 +91,11 @@ namespace Temporal.Tests
         }
 
         [Fact]
-        public void Now_ThrowsWhenNoTimeProvidersAreConfigured()
-        {
-            Assert.Throws<ApplicationException>(() =>
-            {
-                var now = TemporalTime.Now;
-            });
-        }
-
-        [Fact]
-        public void Now_ThrowsWhenNoTimeProvidersHaveTheTime()
-        {
-            TemporalTime.AddTimeProvider(new NoTimeTestTimeProvider());
-
-            Assert.Throws<ApplicationException>(() =>
-            {
-                var now = TemporalTime.Now;
-            });
-        }
-
-        [Fact]
         public void Now_ReturnsTheTimeFromTheFirstTimeProviderWithTheTime()
         {
             TemporalTime.AddTimeProvider(new TestTimeProvider());
 
             Assert.Equal(TestTimeProvider.DefaultNow, TemporalTime.Now);
-        }
-
-        [Fact]
-        public void UtcNow_ThrowsWhenNoTimeProvidersAreConfigured()
-        {
-            Assert.Throws<ApplicationException>(() =>
-            {
-                var now = TemporalTime.UtcNow;
-            });
-        }
-
-        [Fact]
-        public void UtcNow_ThrowsWhenNoTimeProvidersHaveTheTime()
-        {
-            TemporalTime.AddTimeProvider(new NoTimeTestTimeProvider());
-
-            Assert.Throws<ApplicationException>(() =>
-            {
-                var now = TemporalTime.UtcNow;
-            });
         }
 
         [Fact]


### PR DESCRIPTION
- If no time provider is specified, use `SystemClockProvider`.
- Version `1.0.0-alpha3`.